### PR TITLE
fix(deckgl-typings): Move the typing of deck.gl from dep to devDep

### DIFF
--- a/packages/terracotta-react/package.json
+++ b/packages/terracotta-react/package.json
@@ -28,7 +28,6 @@
 		"node": ">=10"
 	},
 	"dependencies": {
-		"@danmarshall/deckgl-typings": "^4.9.8",
 		"@deck.gl/core": "^8.6.3",
 		"@deck.gl/geo-layers": "^8.6.3",
 		"@deck.gl/layers": "^8.6.3"
@@ -39,6 +38,7 @@
 		"react-dom": ">=17"
 	},
 	"devDependencies": {
+		"@danmarshall/deckgl-typings": "^4.9.8",
 		"tsdx": "^0.14.1"
 	}
 }


### PR DESCRIPTION
It fixes the dependencies error caused by the deck.gl typings when installing the package